### PR TITLE
Add multi-provider LLM support (OpenAI + MiniMax)

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Explore our extensive list of prompt engineering techniques, ranging from basic 
 | 20 | 🌍 **Advanced Applications** | [Ethical Considerations](https://github.com/NirDiamant/Prompt_Engineering/blob/main/all_prompt_engineering_techniques/ethical-prompt-engineering.ipynb) | Bias avoidance and inclusivity |
 | 21 | 🌍 **Advanced Applications** | [Prompt Security](https://github.com/NirDiamant/Prompt_Engineering/blob/main/all_prompt_engineering_techniques/prompt-security-and-safety.ipynb) | Preventing injections |
 | 22 | 🌍 **Advanced Applications** | [Effectiveness Evaluation](https://github.com/NirDiamant/Prompt_Engineering/blob/main/all_prompt_engineering_techniques/evaluating-prompt-effectiveness.ipynb) | Evaluating prompt performance |
+| 23 | 🌍 **Advanced Applications** | [Multi-Provider Prompting](https://github.com/NirDiamant/Prompt_Engineering/blob/main/all_prompt_engineering_techniques/multi-provider-prompting.ipynb) | Using and comparing multiple LLM providers (OpenAI, MiniMax) |
 
 ### 🌱 Fundamental Concepts
 
@@ -310,12 +311,20 @@ Explore our extensive list of prompt engineering techniques, ranging from basic 
     Covers techniques for prompt injection prevention, content filtering implementation, and testing the effectiveness of security and safety measures.
 
 22. **[Evaluating Prompt Effectiveness](https://github.com/NirDiamant/Prompt_Engineering/blob/main/all_prompt_engineering_techniques/evaluating-prompt-effectiveness.ipynb)**
-    
+
     #### Overview 🔎
     Explores methods and techniques for evaluating the effectiveness of prompts in AI language models.
 
     #### Implementation 🛠️
     Covers setting up evaluation metrics, implementing manual and automated evaluation techniques, and providing practical examples using OpenAI and LangChain.
+
+23. **[Multi-Provider Prompting](https://github.com/NirDiamant/Prompt_Engineering/blob/main/all_prompt_engineering_techniques/multi-provider-prompting.ipynb)**
+
+    #### Overview 🔎
+    Demonstrates how to use multiple LLM providers (OpenAI, MiniMax) with the same prompt engineering techniques, enabling provider comparison and avoiding vendor lock-in.
+
+    #### Implementation 🛠️
+    Covers the `utils/llm_provider.py` helper for multi-provider support, side-by-side provider comparison for zero-shot/few-shot/CoT prompts, auto-detection via environment variables, and using MiniMax M2.5/M2.7 models through an OpenAI-compatible API.
 
 ## Getting Started
 

--- a/all_prompt_engineering_techniques/multi-provider-prompting.ipynb
+++ b/all_prompt_engineering_techniques/multi-provider-prompting.ipynb
@@ -1,0 +1,387 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Multi-Provider Prompting Tutorial\n",
+    "\n",
+    "## Overview\n",
+    "\n",
+    "This tutorial demonstrates how to use multiple LLM providers with the prompt engineering techniques covered in this repository. By supporting different providers, you can compare model outputs, avoid vendor lock-in, and leverage each provider's unique strengths.\n",
+    "\n",
+    "## Motivation\n",
+    "\n",
+    "Most prompt engineering tutorials are tightly coupled to a single LLM provider (typically OpenAI). However, in practice, teams often evaluate prompts across multiple providers to:\n",
+    "\n",
+    "- **Compare quality**: Different models may excel at different tasks.\n",
+    "- **Reduce costs**: Some providers offer competitive pricing for comparable quality.\n",
+    "- **Improve reliability**: Having a fallback provider ensures availability.\n",
+    "- **Explore options**: Newer providers like MiniMax offer high-performance models with OpenAI-compatible APIs.\n",
+    "\n",
+    "## Key Components\n",
+    "\n",
+    "1. **`utils/llm_provider.py`**: A helper module providing `get_llm()` that creates a LangChain-compatible LLM for any supported provider.\n",
+    "2. **Provider Auto-Detection**: Automatically selects the provider based on available API keys.\n",
+    "3. **Consistent Interface**: All providers return a `ChatOpenAI` instance, so existing prompt templates and chains work without modification.\n",
+    "\n",
+    "## Supported Providers\n",
+    "\n",
+    "| Provider | Models | API Key Env Var | Base URL |\n",
+    "|----------|--------|-----------------|----------|\n",
+    "| OpenAI | gpt-4o-mini, gpt-4o, etc. | `OPENAI_API_KEY` | (default) |\n",
+    "| MiniMax | MiniMax-M2.5, MiniMax-M2.7, MiniMax-M2.5-highspeed | `MINIMAX_API_KEY` | `https://api.minimax.io/v1` |\n",
+    "\n",
+    "## Conclusion\n",
+    "\n",
+    "By the end of this tutorial, you will:\n",
+    "\n",
+    "1. Know how to configure and switch between LLM providers.\n",
+    "2. Be able to compare prompt outputs across providers.\n",
+    "3. Understand how to auto-detect providers from environment variables.\n",
+    "4. Have a reusable pattern for multi-provider prompt engineering."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup\n",
+    "\n",
+    "First, install the required dependencies and configure your API keys in a `.env` file."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import sys\n",
+    "from dotenv import load_dotenv\n",
+    "\n",
+    "# Add the project root to sys.path so we can import utils\n",
+    "sys.path.insert(0, os.path.join(os.getcwd(), \"..\"))\n",
+    "\n",
+    "load_dotenv()\n",
+    "\n",
+    "from utils.llm_provider import get_llm, get_provider_name, SUPPORTED_PROVIDERS\n",
+    "from langchain.prompts import PromptTemplate\n",
+    "\n",
+    "print(f\"Supported providers: {', '.join(SUPPORTED_PROVIDERS)}\")\n",
+    "print(f\"Active provider: {get_provider_name()}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Basic Provider Usage\n",
+    "\n",
+    "The `get_llm()` function creates a LangChain `ChatOpenAI` instance for any supported provider. You can specify the provider explicitly, or let it auto-detect from the `LLM_PROVIDER` environment variable."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Auto-detect provider from environment\n",
+    "llm = get_llm()\n",
+    "\n",
+    "# Or explicitly choose a provider:\n",
+    "# llm = get_llm(provider=\"openai\")\n",
+    "# llm = get_llm(provider=\"minimax\", model=\"MiniMax-M2.5\")\n",
+    "\n",
+    "prompt = PromptTemplate.from_template(\n",
+    "    \"Explain the concept of {topic} in exactly two sentences.\"\n",
+    ")\n",
+    "chain = prompt | llm\n",
+    "\n",
+    "result = chain.invoke({\"topic\": \"prompt engineering\"}).content\n",
+    "print(f\"Provider: {get_provider_name()}\")\n",
+    "print(f\"Response: {result}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Comparing Providers Side-by-Side\n",
+    "\n",
+    "One of the most valuable applications of multi-provider support is comparing how different models respond to the same prompt. This helps you:\n",
+    "- Evaluate prompt robustness across models\n",
+    "- Identify provider-specific strengths\n",
+    "- Choose the best provider for your use case"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def compare_providers(prompt_template, variables, providers=None):\n",
+    "    \"\"\"Run the same prompt across multiple providers and display results.\"\"\"\n",
+    "    if providers is None:\n",
+    "        # Only compare providers whose API keys are available\n",
+    "        providers = []\n",
+    "        if os.getenv(\"OPENAI_API_KEY\"):\n",
+    "            providers.append(\"openai\")\n",
+    "        if os.getenv(\"MINIMAX_API_KEY\"):\n",
+    "            providers.append(\"minimax\")\n",
+    "\n",
+    "    prompt = PromptTemplate.from_template(prompt_template)\n",
+    "\n",
+    "    for provider in providers:\n",
+    "        try:\n",
+    "            llm = get_llm(provider=provider)\n",
+    "            chain = prompt | llm\n",
+    "            result = chain.invoke(variables).content\n",
+    "            print(f\"=== {provider.upper()} ===\")\n",
+    "            print(result)\n",
+    "            print()\n",
+    "        except ValueError as e:\n",
+    "            print(f\"=== {provider.upper()} ===\")\n",
+    "            print(f\"Skipped: {e}\")\n",
+    "            print()\n",
+    "\n",
+    "\n",
+    "# Compare a zero-shot classification prompt\n",
+    "compare_providers(\n",
+    "    prompt_template=\"\"\"Classify the sentiment of the following text as Positive, Negative, or Neutral.\n",
+    "Respond with only the classification label.\n",
+    "\n",
+    "Text: {text}\n",
+    "\n",
+    "Sentiment:\"\"\",\n",
+    "    variables={\"text\": \"The new park downtown is a wonderful addition to the neighborhood.\"},\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Few-Shot Learning Across Providers\n",
+    "\n",
+    "Few-shot prompts should work consistently across providers. Let's verify this with a classification task."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "few_shot_template = \"\"\"Classify the following customer review into one of these categories:\n",
+    "Product Quality, Customer Service, Shipping, or Pricing.\n",
+    "\n",
+    "Examples:\n",
+    "Review: \"The fabric feels cheap and started fraying after one wash.\"\n",
+    "Category: Product Quality\n",
+    "\n",
+    "Review: \"The support team resolved my issue within 10 minutes.\"\n",
+    "Category: Customer Service\n",
+    "\n",
+    "Review: \"My order arrived a week late and the box was damaged.\"\n",
+    "Category: Shipping\n",
+    "\n",
+    "Review: \"At $15, this is a steal compared to similar products.\"\n",
+    "Category: Pricing\n",
+    "\n",
+    "Now classify this review:\n",
+    "Review: \"{review}\"\n",
+    "Category:\"\"\"\n",
+    "\n",
+    "compare_providers(\n",
+    "    prompt_template=few_shot_template,\n",
+    "    variables={\"review\": \"I was charged twice for the same item and the refund took forever.\"},\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Chain of Thought with Different Providers\n",
+    "\n",
+    "Chain of Thought (CoT) prompting asks the model to reason step by step. Different providers may produce varying levels of reasoning detail."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cot_template = \"\"\"Solve the following problem step by step. Show your reasoning clearly.\n",
+    "\n",
+    "Problem: {problem}\n",
+    "\n",
+    "Solution:\"\"\"\n",
+    "\n",
+    "compare_providers(\n",
+    "    prompt_template=cot_template,\n",
+    "    variables={\n",
+    "        \"problem\": (\n",
+    "            \"A store offers a 20% discount on all items. \"\n",
+    "            \"If a jacket originally costs $85, and there is an additional \"\n",
+    "            \"8% sales tax applied after the discount, what is the final price?\"\n",
+    "        )\n",
+    "    },\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5. Role Prompting with Provider Selection\n",
+    "\n",
+    "Role prompting assigns a persona to the model. Let's see how different providers interpret the same role."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "role_template = \"\"\"You are a {role}. Based on your expertise, answer the following question.\n",
+    "Keep your response concise (3-4 sentences).\n",
+    "\n",
+    "Question: {question}\n",
+    "\n",
+    "Answer:\"\"\"\n",
+    "\n",
+    "compare_providers(\n",
+    "    prompt_template=role_template,\n",
+    "    variables={\n",
+    "        \"role\": \"senior cybersecurity analyst\",\n",
+    "        \"question\": \"What are the top three practices every organization should adopt to prevent phishing attacks?\",\n",
+    "    },\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 6. Using MiniMax Directly\n",
+    "\n",
+    "MiniMax offers high-performance models (M2.5 and M2.7) with an OpenAI-compatible API. Here is how to use MiniMax directly."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create a MiniMax LLM instance\n",
+    "# Requires MINIMAX_API_KEY in your .env file\n",
+    "# Get your API key at https://platform.minimaxi.com/\n",
+    "try:\n",
+    "    minimax_llm = get_llm(provider=\"minimax\", model=\"MiniMax-M2.5\")\n",
+    "\n",
+    "    prompt = PromptTemplate.from_template(\n",
+    "        \"\"\"Generate a creative product name and a one-line tagline for the following concept.\n",
+    "\n",
+    "Concept: {concept}\n",
+    "\n",
+    "Product Name:\n",
+    "Tagline:\"\"\"\n",
+    "    )\n",
+    "    chain = prompt | minimax_llm\n",
+    "\n",
+    "    result = chain.invoke(\n",
+    "        {\"concept\": \"An AI-powered notebook that organizes your thoughts automatically\"}\n",
+    "    ).content\n",
+    "    print(\"MiniMax Response:\")\n",
+    "    print(result)\n",
+    "\n",
+    "except ValueError as e:\n",
+    "    print(f\"MiniMax not configured: {e}\")\n",
+    "    print(\"Set MINIMAX_API_KEY in your .env file to use MiniMax.\")\n",
+    "    print(\"Get your API key at https://platform.minimaxi.com/\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 7. Switching Providers via Environment Variable\n",
+    "\n",
+    "You can control the default provider by setting the `LLM_PROVIDER` environment variable. This is useful for CI/CD pipelines or team-wide configuration."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Demonstrate environment-based provider switching\n",
+    "original_provider = os.getenv(\"LLM_PROVIDER\", \"\")\n",
+    "\n",
+    "for provider_name in SUPPORTED_PROVIDERS:\n",
+    "    os.environ[\"LLM_PROVIDER\"] = provider_name\n",
+    "    detected = get_provider_name()\n",
+    "    print(f\"LLM_PROVIDER={provider_name!r} -> get_provider_name() = {detected!r}\")\n",
+    "\n",
+    "# Restore original\n",
+    "if original_provider:\n",
+    "    os.environ[\"LLM_PROVIDER\"] = original_provider\n",
+    "else:\n",
+    "    os.environ.pop(\"LLM_PROVIDER\", None)\n",
+    "\n",
+    "print(f\"\\nRestored provider: {get_provider_name()!r}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Summary\n",
+    "\n",
+    "In this tutorial, we explored:\n",
+    "\n",
+    "1. **`get_llm()`** - A unified function to create LLM instances for any supported provider.\n",
+    "2. **Provider comparison** - Running the same prompt across providers to evaluate output quality.\n",
+    "3. **Technique portability** - Zero-shot, few-shot, CoT, and role prompting all work consistently across providers.\n",
+    "4. **Auto-detection** - The system automatically selects a provider based on available API keys.\n",
+    "5. **Environment configuration** - Use `LLM_PROVIDER` to control the default provider.\n",
+    "\n",
+    "### Adding a New Provider\n",
+    "\n",
+    "To add support for another OpenAI-compatible provider, simply add its configuration to `_PROVIDER_DEFAULTS` in `utils/llm_provider.py`. The same LangChain chains and prompts will work automatically.\n",
+    "\n",
+    "### Recommended Models\n",
+    "\n",
+    "| Provider | Model | Best For |\n",
+    "|----------|-------|----------|\n",
+    "| OpenAI | gpt-4o-mini | General use, cost-effective |\n",
+    "| OpenAI | gpt-4o | Complex reasoning, highest quality |\n",
+    "| MiniMax | MiniMax-M2.5 | General use, large 204K context |\n",
+    "| MiniMax | MiniMax-M2.7 | Latest model, best quality |\n",
+    "| MiniMax | MiniMax-M2.5-highspeed | Fast inference, 204K context |"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/tests/test_integration_minimax.py
+++ b/tests/test_integration_minimax.py
@@ -1,0 +1,57 @@
+"""Integration tests for MiniMax provider.
+
+These tests make real API calls to the MiniMax API and require
+the MINIMAX_API_KEY environment variable to be set.
+
+Run with:
+    pytest tests/test_integration_minimax.py -v
+"""
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from utils.llm_provider import get_llm
+
+# Skip all tests if MINIMAX_API_KEY is not set
+pytestmark = pytest.mark.skipif(
+    not os.getenv("MINIMAX_API_KEY"),
+    reason="MINIMAX_API_KEY not set",
+)
+
+
+class TestMiniMaxIntegration:
+    """Integration tests that call the MiniMax API."""
+
+    def test_basic_completion(self):
+        """MiniMax should return a non-empty response for a simple prompt."""
+        llm = get_llm(provider="minimax", model="MiniMax-M2.5")
+        result = llm.invoke("Say hello in exactly three words.").content
+        assert isinstance(result, str)
+        assert len(result.strip()) > 0
+
+    def test_sentiment_classification(self):
+        """MiniMax should correctly classify obvious sentiment."""
+        llm = get_llm(provider="minimax", model="MiniMax-M2.5")
+        result = llm.invoke(
+            "Classify the sentiment as Positive, Negative, or Neutral. "
+            "Respond with only the label.\n\n"
+            "Text: I absolutely love this product!\n\n"
+            "Sentiment:"
+        ).content.strip().lower()
+        assert "positive" in result
+
+    def test_chain_with_prompt_template(self):
+        """MiniMax should work with LangChain PromptTemplate chains."""
+        from langchain_core.prompts import PromptTemplate
+
+        llm = get_llm(provider="minimax")
+        prompt = PromptTemplate.from_template(
+            "What is the capital of {country}? Reply with just the city name."
+        )
+        chain = prompt | llm
+        result = chain.invoke({"country": "France"}).content.strip()
+        assert "Paris" in result

--- a/tests/test_llm_provider.py
+++ b/tests/test_llm_provider.py
@@ -1,0 +1,230 @@
+"""Unit tests for utils.llm_provider module."""
+
+import os
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+# Ensure project root is importable
+import sys
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from utils.llm_provider import (
+    get_llm,
+    get_provider_name,
+    SUPPORTED_PROVIDERS,
+    _PROVIDER_DEFAULTS,
+)
+
+
+# ---------------------------------------------------------------------------
+# get_provider_name tests
+# ---------------------------------------------------------------------------
+
+class TestGetProviderName:
+    """Tests for provider auto-detection logic."""
+
+    def test_default_is_openai(self):
+        """Default provider should be openai when no env vars are set."""
+        with patch.dict(os.environ, {}, clear=True):
+            os.environ.pop("LLM_PROVIDER", None)
+            os.environ.pop("MINIMAX_API_KEY", None)
+            os.environ.pop("OPENAI_API_KEY", None)
+            assert get_provider_name() == "openai"
+
+    def test_explicit_openai(self):
+        """LLM_PROVIDER=openai should select openai."""
+        with patch.dict(os.environ, {"LLM_PROVIDER": "openai"}, clear=False):
+            assert get_provider_name() == "openai"
+
+    def test_explicit_minimax(self):
+        """LLM_PROVIDER=minimax should select minimax."""
+        with patch.dict(os.environ, {"LLM_PROVIDER": "minimax"}, clear=False):
+            assert get_provider_name() == "minimax"
+
+    def test_explicit_minimax_uppercase(self):
+        """LLM_PROVIDER should be case-insensitive."""
+        with patch.dict(os.environ, {"LLM_PROVIDER": "MiniMax"}, clear=False):
+            assert get_provider_name() == "minimax"
+
+    def test_auto_detect_minimax_when_only_minimax_key(self):
+        """Auto-detect minimax when MINIMAX_API_KEY is set but OPENAI_API_KEY is not."""
+        env = {"MINIMAX_API_KEY": "test-key"}
+        with patch.dict(os.environ, env, clear=True):
+            os.environ.pop("LLM_PROVIDER", None)
+            os.environ.pop("OPENAI_API_KEY", None)
+            assert get_provider_name() == "minimax"
+
+    def test_prefers_openai_when_both_keys(self):
+        """When both API keys are set and LLM_PROVIDER is unset, default to openai."""
+        env = {"MINIMAX_API_KEY": "mm-key", "OPENAI_API_KEY": "oai-key"}
+        with patch.dict(os.environ, env, clear=True):
+            os.environ.pop("LLM_PROVIDER", None)
+            assert get_provider_name() == "openai"
+
+    def test_unknown_provider_falls_through(self):
+        """An unknown LLM_PROVIDER value should fall through to default logic."""
+        with patch.dict(os.environ, {"LLM_PROVIDER": "unknown_provider"}, clear=True):
+            os.environ.pop("MINIMAX_API_KEY", None)
+            os.environ.pop("OPENAI_API_KEY", None)
+            assert get_provider_name() == "openai"
+
+    def test_whitespace_handling(self):
+        """LLM_PROVIDER with extra whitespace should still work."""
+        with patch.dict(os.environ, {"LLM_PROVIDER": "  minimax  "}, clear=False):
+            assert get_provider_name() == "minimax"
+
+
+# ---------------------------------------------------------------------------
+# get_llm tests
+# ---------------------------------------------------------------------------
+
+class TestGetLlm:
+    """Tests for LLM instance creation."""
+
+    @patch("utils.llm_provider.ChatOpenAI")
+    def test_openai_defaults(self, mock_chat):
+        """OpenAI provider should use correct defaults."""
+        with patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"}, clear=False):
+            get_llm(provider="openai")
+            mock_chat.assert_called_once()
+            kwargs = mock_chat.call_args[1]
+            assert kwargs["model"] == "gpt-4o-mini"
+            assert kwargs["temperature"] == 0.0
+            assert kwargs["api_key"] == "test-key"
+            assert "base_url" not in kwargs
+
+    @patch("utils.llm_provider.ChatOpenAI")
+    def test_minimax_defaults(self, mock_chat):
+        """MiniMax provider should use correct base_url and model."""
+        with patch.dict(os.environ, {"MINIMAX_API_KEY": "mm-key"}, clear=False):
+            get_llm(provider="minimax")
+            mock_chat.assert_called_once()
+            kwargs = mock_chat.call_args[1]
+            assert kwargs["model"] == "MiniMax-M2.5"
+            assert kwargs["base_url"] == "https://api.minimax.io/v1"
+            assert kwargs["api_key"] == "mm-key"
+
+    @patch("utils.llm_provider.ChatOpenAI")
+    def test_custom_model(self, mock_chat):
+        """Custom model parameter should override the default."""
+        with patch.dict(os.environ, {"MINIMAX_API_KEY": "mm-key"}, clear=False):
+            get_llm(provider="minimax", model="MiniMax-M2.7")
+            kwargs = mock_chat.call_args[1]
+            assert kwargs["model"] == "MiniMax-M2.7"
+
+    @patch("utils.llm_provider.ChatOpenAI")
+    def test_custom_temperature(self, mock_chat):
+        """Custom temperature should be passed through."""
+        with patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"}, clear=False):
+            get_llm(provider="openai", temperature=0.7)
+            kwargs = mock_chat.call_args[1]
+            assert kwargs["temperature"] == 0.7
+
+    @patch("utils.llm_provider.ChatOpenAI")
+    def test_temperature_clamped_to_min(self, mock_chat):
+        """Negative temperature should be clamped to provider minimum."""
+        with patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"}, clear=False):
+            get_llm(provider="openai", temperature=-1.0)
+            kwargs = mock_chat.call_args[1]
+            assert kwargs["temperature"] == 0.0
+
+    @patch("utils.llm_provider.ChatOpenAI")
+    def test_max_tokens(self, mock_chat):
+        """Custom max_tokens should be passed through."""
+        with patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"}, clear=False):
+            get_llm(provider="openai", max_tokens=2048)
+            kwargs = mock_chat.call_args[1]
+            assert kwargs["max_tokens"] == 2048
+
+    @patch("utils.llm_provider.ChatOpenAI")
+    def test_extra_kwargs(self, mock_chat):
+        """Extra keyword arguments should be forwarded to ChatOpenAI."""
+        with patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"}, clear=False):
+            get_llm(provider="openai", top_p=0.9)
+            kwargs = mock_chat.call_args[1]
+            assert kwargs["top_p"] == 0.9
+
+    def test_missing_api_key_raises(self):
+        """Missing API key should raise ValueError."""
+        with patch.dict(os.environ, {}, clear=True):
+            os.environ.pop("OPENAI_API_KEY", None)
+            os.environ.pop("MINIMAX_API_KEY", None)
+            os.environ.pop("LLM_PROVIDER", None)
+            with pytest.raises(ValueError, match="API key not found"):
+                get_llm(provider="openai")
+
+    def test_unsupported_provider_raises(self):
+        """Unsupported provider name should raise ValueError."""
+        with pytest.raises(ValueError, match="Unsupported provider"):
+            get_llm(provider="nonexistent_provider")
+
+    @patch("utils.llm_provider.ChatOpenAI")
+    def test_auto_detect_minimax(self, mock_chat):
+        """When provider=None and only MINIMAX_API_KEY is set, use minimax."""
+        env = {"MINIMAX_API_KEY": "mm-key"}
+        with patch.dict(os.environ, env, clear=True):
+            os.environ.pop("OPENAI_API_KEY", None)
+            os.environ.pop("LLM_PROVIDER", None)
+            get_llm()
+            kwargs = mock_chat.call_args[1]
+            assert kwargs["base_url"] == "https://api.minimax.io/v1"
+
+    @patch("utils.llm_provider.ChatOpenAI")
+    def test_minimax_m27_model(self, mock_chat):
+        """MiniMax M2.7 model should work correctly."""
+        with patch.dict(os.environ, {"MINIMAX_API_KEY": "mm-key"}, clear=False):
+            get_llm(provider="minimax", model="MiniMax-M2.7")
+            kwargs = mock_chat.call_args[1]
+            assert kwargs["model"] == "MiniMax-M2.7"
+            assert kwargs["base_url"] == "https://api.minimax.io/v1"
+
+    @patch("utils.llm_provider.ChatOpenAI")
+    def test_minimax_highspeed_model(self, mock_chat):
+        """MiniMax M2.5-highspeed model should work correctly."""
+        with patch.dict(os.environ, {"MINIMAX_API_KEY": "mm-key"}, clear=False):
+            get_llm(provider="minimax", model="MiniMax-M2.5-highspeed")
+            kwargs = mock_chat.call_args[1]
+            assert kwargs["model"] == "MiniMax-M2.5-highspeed"
+
+
+# ---------------------------------------------------------------------------
+# Provider configuration tests
+# ---------------------------------------------------------------------------
+
+class TestProviderConfig:
+    """Tests for provider configuration constants."""
+
+    def test_supported_providers_tuple(self):
+        """SUPPORTED_PROVIDERS should be a tuple of strings."""
+        assert isinstance(SUPPORTED_PROVIDERS, tuple)
+        assert all(isinstance(p, str) for p in SUPPORTED_PROVIDERS)
+
+    def test_openai_in_providers(self):
+        assert "openai" in SUPPORTED_PROVIDERS
+
+    def test_minimax_in_providers(self):
+        assert "minimax" in SUPPORTED_PROVIDERS
+
+    def test_each_provider_has_defaults(self):
+        """Every supported provider must have an entry in _PROVIDER_DEFAULTS."""
+        for provider in SUPPORTED_PROVIDERS:
+            assert provider in _PROVIDER_DEFAULTS
+
+    def test_defaults_have_required_keys(self):
+        """Each provider's defaults must have base_url, default_model, api_key_env."""
+        required_keys = {"base_url", "default_model", "api_key_env", "temperature_min"}
+        for provider, defaults in _PROVIDER_DEFAULTS.items():
+            assert required_keys.issubset(defaults.keys()), (
+                f"Provider {provider!r} missing keys: "
+                f"{required_keys - defaults.keys()}"
+            )
+
+    def test_minimax_base_url(self):
+        assert _PROVIDER_DEFAULTS["minimax"]["base_url"] == "https://api.minimax.io/v1"
+
+    def test_minimax_default_model(self):
+        assert _PROVIDER_DEFAULTS["minimax"]["default_model"] == "MiniMax-M2.5"
+
+    def test_minimax_api_key_env(self):
+        assert _PROVIDER_DEFAULTS["minimax"]["api_key_env"] == "MINIMAX_API_KEY"

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,0 +1,3 @@
+"""Utility modules for the Prompt Engineering tutorials."""
+
+from utils.llm_provider import get_llm, get_provider_name, SUPPORTED_PROVIDERS

--- a/utils/llm_provider.py
+++ b/utils/llm_provider.py
@@ -1,0 +1,139 @@
+"""
+Multi-provider LLM helper for Prompt Engineering tutorials.
+
+Supports multiple LLM providers through a unified interface using LangChain's
+ChatOpenAI class (since many providers offer OpenAI-compatible APIs).
+
+Supported providers:
+    - openai:  OpenAI GPT models (default)
+    - minimax: MiniMax M2.5 / M2.7 models via OpenAI-compatible API
+
+Usage:
+    from utils.llm_provider import get_llm
+
+    # Use default provider (OpenAI)
+    llm = get_llm()
+
+    # Use MiniMax
+    llm = get_llm(provider="minimax")
+
+    # Auto-detect from LLM_PROVIDER env var
+    llm = get_llm()  # reads LLM_PROVIDER env var if set
+
+Environment variables:
+    LLM_PROVIDER      - Provider name ("openai" or "minimax"), default "openai"
+    OPENAI_API_KEY     - API key for OpenAI
+    MINIMAX_API_KEY    - API key for MiniMax
+"""
+
+import os
+from typing import Optional
+
+from dotenv import load_dotenv
+from langchain_openai import ChatOpenAI
+
+load_dotenv()
+
+SUPPORTED_PROVIDERS = ("openai", "minimax")
+
+# Provider defaults: (base_url, default_model, api_key_env, temperature_min)
+_PROVIDER_DEFAULTS = {
+    "openai": {
+        "base_url": None,  # uses langchain default
+        "default_model": "gpt-4o-mini",
+        "api_key_env": "OPENAI_API_KEY",
+        "temperature_min": 0.0,
+    },
+    "minimax": {
+        "base_url": "https://api.minimax.io/v1",
+        "default_model": "MiniMax-M2.5",
+        "api_key_env": "MINIMAX_API_KEY",
+        "temperature_min": 0.0,
+    },
+}
+
+
+def get_provider_name() -> str:
+    """Return the active provider name from ``LLM_PROVIDER`` env var.
+
+    Defaults to ``"openai"`` when the variable is unset.  If
+    ``MINIMAX_API_KEY`` is set but ``OPENAI_API_KEY`` is not, auto-selects
+    ``"minimax"``.
+    """
+    provider = os.getenv("LLM_PROVIDER", "").strip().lower()
+    if provider and provider in SUPPORTED_PROVIDERS:
+        return provider
+
+    # Auto-detect: prefer MiniMax when only its key is available
+    if os.getenv("MINIMAX_API_KEY") and not os.getenv("OPENAI_API_KEY"):
+        return "minimax"
+
+    return "openai"
+
+
+def get_llm(
+    provider: Optional[str] = None,
+    model: Optional[str] = None,
+    temperature: float = 0.0,
+    max_tokens: int = 1024,
+    **kwargs,
+) -> ChatOpenAI:
+    """Create a LangChain ``ChatOpenAI`` instance for the chosen provider.
+
+    Parameters
+    ----------
+    provider : str, optional
+        One of ``"openai"`` or ``"minimax"``.  When *None*, falls back to
+        :func:`get_provider_name` (reads ``LLM_PROVIDER`` env var).
+    model : str, optional
+        Model identifier.  When *None*, uses the provider's default model.
+    temperature : float
+        Sampling temperature.  Clamped to the provider's minimum if needed.
+    max_tokens : int
+        Maximum number of tokens to generate.
+    **kwargs
+        Forwarded to ``ChatOpenAI``.
+
+    Returns
+    -------
+    ChatOpenAI
+        A ready-to-use chat model instance.
+
+    Raises
+    ------
+    ValueError
+        If the provider is not recognised or no API key is found.
+    """
+    if provider is None:
+        provider = get_provider_name()
+    provider = provider.strip().lower()
+
+    if provider not in _PROVIDER_DEFAULTS:
+        raise ValueError(
+            f"Unsupported provider '{provider}'. "
+            f"Choose from: {', '.join(SUPPORTED_PROVIDERS)}"
+        )
+
+    defaults = _PROVIDER_DEFAULTS[provider]
+    api_key = os.getenv(defaults["api_key_env"], "")
+    if not api_key:
+        raise ValueError(
+            f"API key not found. Set the {defaults['api_key_env']} "
+            f"environment variable."
+        )
+
+    model = model or defaults["default_model"]
+    temperature = max(temperature, defaults["temperature_min"])
+
+    init_kwargs = {
+        "model": model,
+        "temperature": temperature,
+        "max_tokens": max_tokens,
+        "api_key": api_key,
+        **kwargs,
+    }
+
+    if defaults["base_url"] is not None:
+        init_kwargs["base_url"] = defaults["base_url"]
+
+    return ChatOpenAI(**init_kwargs)


### PR DESCRIPTION
## Summary

- Add `utils/llm_provider.py` — a multi-provider LLM factory that creates LangChain-compatible chat model instances for **OpenAI** and **MiniMax** via a single `get_llm()` function
- Add tutorial notebook **#23: Multi-Provider Prompting** demonstrating side-by-side provider comparison for zero-shot, few-shot, chain-of-thought, and role prompting techniques
- MiniMax M2.5/M2.7 models available through their OpenAI-compatible API at `https://api.minimax.io/v1`
- Auto-detection: when only `MINIMAX_API_KEY` is set (no `OPENAI_API_KEY`), the system automatically selects MiniMax as the default provider

### Files changed (7 files, 826 additions)

| File | Description |
|------|-------------|
| `utils/llm_provider.py` | Multi-provider factory with auto-detection, temperature clamping, configurable defaults |
| `utils/__init__.py` | Package init exporting `get_llm`, `get_provider_name`, `SUPPORTED_PROVIDERS` |
| `all_prompt_engineering_techniques/multi-provider-prompting.ipynb` | Tutorial notebook (7 sections) |
| `tests/test_llm_provider.py` | 28 unit tests |
| `tests/test_integration_minimax.py` | 3 integration tests (live API) |
| `README.md` | Added technique #23 to table and detailed section |
| `tests/__init__.py` | Test package init |

## Test plan

- [x] 28 unit tests pass (provider detection, LLM creation, config validation, edge cases)
- [x] 3 integration tests pass with live MiniMax API (basic completion, sentiment classification, prompt template chain)
- [ ] Verify notebook renders correctly on GitHub
- [ ] Run notebook cells with both OpenAI and MiniMax API keys


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added multi-provider LLM support, enabling seamless use of OpenAI and MiniMax with a unified interface
  * Automatic provider detection via environment variables

* **Documentation**
  * New tutorial notebook demonstrating multi-provider prompting workflows and side-by-side provider comparisons
  * Updated README with multi-provider prompting technique documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->