### PR TITLE
Update RAG promo pricing + add PE countdown callout

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Welcome to one of the most extensive and dynamic collections of Prompt Engineeri
 <a href="https://europe-west1-rag-techniques-views-tracker.cloudfunctions.net/rag-techniques-tracker?notebook=prompt-engineering--readme&click=book-buy-amazon-image&target=https%3A%2F%2Fwww.amazon.com%2Fdp%2FB0D76734SZ%3Ftag%3Ddiamantai-pe-20&text=Best%20Seller%20Image"><img src="images/rag_book_best_seller.png" alt="#1 Best Seller in Generative AI on Amazon - Click to buy" width="500"></a>
 
 **[RAG Made Simple](https://europe-west1-rag-techniques-views-tracker.cloudfunctions.net/rag-techniques-tracker?notebook=prompt-engineering--readme&click=book-buy-amazon-title&target=https%3A%2F%2Fwww.amazon.com%2Fdp%2FB0D76734SZ%3Ftag%3Ddiamantai-pe-20&text=RAG%20Made%20Simple)** — **#1 Best Seller on Amazon in Generative AI.**
-22 RAG techniques with intuition, comparisons, and illustrations. **Free with Kindle Unlimited** or **$0.99** launch price (goes up soon).
+22 RAG techniques with intuition, comparisons, and illustrations. **Free with Kindle Unlimited** or **$9.99** on Amazon.
 
 ### 👉 [**Get the book on Amazon**](https://europe-west1-rag-techniques-views-tracker.cloudfunctions.net/rag-techniques-tracker?notebook=prompt-engineering--readme&click=book-buy-amazon-cta&target=https%3A%2F%2Fwww.amazon.com%2Fdp%2FB0D76734SZ%3Ftag%3Ddiamantai-pe-20&text=Get%20the%20book%20on%20Amazon)
 
@@ -67,6 +67,8 @@ Our goal is to provide a valuable resource for everyone - from beginners taking 
 Furthermore, this repository serves as a platform for showcasing innovative prompt engineering techniques. Whether you've developed a novel approach or found an innovative application for existing techniques, we encourage you to share your work with the community.
 
 ## 📖 Get the Fully Explained Version of This Repo
+
+> 🔥 **THIS WEEK ONLY (April 15-21)**: The Kindle edition is on a Kindle Countdown Deal at **$2.99**. Grab it now: [**Get Prompt Engineering at countdown pricing**](https://www.amazon.com/dp/B0DZ85RPB5?tag=diamantai-pe-20)
 
 This repository contains **22 hands-on Jupyter Notebook tutorials** covering **key prompt engineering techniques**.
 If you want to go **deeper** with **full explanations, intuitive insights, and structured exercises**, check out the **expanded version in book format**:


### PR DESCRIPTION
Removes the now-stale "$0.99 launch price" messaging and updates the
RAG Made Simple promotion to reflect its current steady-state price
of $9.99 (free with Kindle Unlimited).

The book launched at $0.99 on April 9 as a rank-buying promotional
period. The price was raised to $9.99 on April 13. Existing README
copy was still showing the $0.99 launch price and time-limited urgency
language ("price goes up soon", "before the price changes"), which is
no longer accurate.

Changes are minimal and surgical. No structural changes to the README.
The existing book promotion section retains its layout, image, click-
tracker URL, and Amazon Associates affiliate tag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Updated pricing for "RAG Made Simple" book to $9.99 on Amazon
* Added Kindle Countdown Deal promotion (April 15-21) featuring special $2.99 pricing
* Included enhanced Amazon links and call-to-action for Kindle edition

<!-- end of auto-generated comment: release notes by coderabbit.ai -->