### PR TITLE
Add affiliate CTA for content creators

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ Welcome to one of the most extensive and dynamic collections of Prompt Engineeri
 
 ### 👉 [**Get RAG Made Simple (33% off with code RAGKING)**](https://diamant-ai.com/rag-made-simple?code=RAGKING)
 
+📣 *Teach, write, or run a dev community? Earn 30% recommending RAG Made Simple to your audience: [become an affiliate](https://nirdiamant.gumroad.com/affiliates).*
+
 </div>
 
 > **22 hands-on tutorials** covering everything from basic prompt templates to advanced techniques like chain-of-thought, self-consistency, and tree-of-thought prompting.


### PR DESCRIPTION
Adds a targeted affiliate-recruitment line under the existing book CTA. Framed for people with their own audience (educators, writers, community leaders) so it self-selects promoters rather than waving a discount at direct buyers. Signup: https://nirdiamant.gumroad.com/affiliates

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an affiliate call-to-action encouraging readers to recommend RAG Made Simple, including a corresponding link in the README section near the companion book promotion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->