### PR TITLE
Add view-tracking pixels to README and notebooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,3 +381,5 @@ This project is licensed under a custom non-commercial license - see the [LICENS
 
 Keywords: Prompt Engineering, AI, Machine Learning, Natural Language Processing, LLM, Language Models, NLP, Conversational AI, Zero-Shot Learning, Few-Shot Learning, Chain of Thought
 
+![](https://europe-west1-prompt-eng-views-tracker.cloudfunctions.net/prompt-eng-tracker?notebook=main-readme)
+

--- a/all_prompt_engineering_techniques/ambiguity-clarity.ipynb
+++ b/all_prompt_engineering_techniques/ambiguity-clarity.ipynb
@@ -534,6 +534,13 @@
     "    print(f\"Improved: {improved_prompt}\")\n",
     "    print(\"-\" * 50)"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "![](https://europe-west1-prompt-eng-views-tracker.cloudfunctions.net/prompt-eng-tracker?notebook=all-prompt-engineering-techniques--ambiguity-clarity)"
+   ]
   }
  ],
  "metadata": {

--- a/all_prompt_engineering_techniques/basic-prompt-structures.ipynb
+++ b/all_prompt_engineering_techniques/basic-prompt-structures.ipynb
@@ -169,6 +169,13 @@
     "\n",
     "Understanding these different prompt structures allows you to choose the most appropriate approach for various tasks and create more effective interactions with AI language models."
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "![](https://europe-west1-prompt-eng-views-tracker.cloudfunctions.net/prompt-eng-tracker?notebook=all-prompt-engineering-techniques--basic-prompt-structures)"
+   ]
   }
  ],
  "metadata": {

--- a/all_prompt_engineering_techniques/constrained-guided-generation.ipynb
+++ b/all_prompt_engineering_techniques/constrained-guided-generation.ipynb
@@ -401,6 +401,13 @@
     "output = chain.invoke(input_variables).content\n",
     "display_output(output)"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "![](https://europe-west1-prompt-eng-views-tracker.cloudfunctions.net/prompt-eng-tracker?notebook=all-prompt-engineering-techniques--constrained-guided-generation)"
+   ]
   }
  ],
  "metadata": {

--- a/all_prompt_engineering_techniques/cot-prompting.ipynb
+++ b/all_prompt_engineering_techniques/cot-prompting.ipynb
@@ -262,6 +262,13 @@
    "metadata": {},
    "outputs": [],
    "source": "llm = ChatOpenAI(model=\"gpt-4o\")\n\nlogical_reasoning_prompt = PromptTemplate(\n    input_variables=[\"scenario\"],\n    template=\"\"\"Analyze the following logical puzzle thoroughly. Follow these steps in your analysis:\n\nList the Facts:\n\nSummarize all the given information and statements clearly.\nIdentify all the characters or elements involved.\nIdentify Possible Roles or Conditions:\n\nDetermine all possible roles, behaviors, or states applicable to the characters or elements (e.g., truth-teller, liar, alternator).\nNote the Constraints:\n\nOutline any rules, constraints, or relationships specified in the puzzle.\nGenerate Possible Scenarios:\n\nSystematically consider all possible combinations of roles or conditions for the characters or elements.\nEnsure that all permutations are accounted for.\nTest Each Scenario:\n\nFor each possible scenario:\nAssume the roles or conditions you've assigned.\nAnalyze each statement based on these assumptions.\nCheck for consistency or contradictions within the scenario.\nEliminate Inconsistent Scenarios:\n\nDiscard any scenarios that lead to contradictions or violate the constraints.\nKeep track of the reasoning for eliminating each scenario.\nConclude the Solution:\n\nIdentify the scenario(s) that remain consistent after testing.\nSummarize the findings.\nProvide a Clear Answer:\n\nState definitively the role or condition of each character or element.\nExplain why this is the only possible solution based on your analysis.\nScenario:\n\n{scenario}\n\nAnalysis:\"\"\")\n\nlogical_reasoning_chain = logical_reasoning_prompt | llm\n\nlogical_puzzle = \"\"\"In a room, there are three people: Amy, Bob, and Charlie. \nOne of them always tells the truth, one always lies, and one alternates between truth and lies. \nAmy says, 'Bob is a liar.' \nBob says, 'Charlie alternates between truth and lies.' \nCharlie says, 'Amy and I are both liars.' \nDetermine the nature (truth-teller, liar, or alternator) of each person.\"\"\"\n\nlogical_reasoning_response = logical_reasoning_chain.invoke(logical_puzzle).content\nprint(logical_reasoning_response)"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "![](https://europe-west1-prompt-eng-views-tracker.cloudfunctions.net/prompt-eng-tracker?notebook=all-prompt-engineering-techniques--cot-prompting)"
+   ]
   }
  ],
  "metadata": {

--- a/all_prompt_engineering_techniques/ethical-prompt-engineering.ipynb
+++ b/all_prompt_engineering_techniques/ethical-prompt-engineering.ipynb
@@ -350,6 +350,13 @@
     "print(\"\\nFairness evaluation of improved response:\")\n",
     "print(fairness_score)"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "![](https://europe-west1-prompt-eng-views-tracker.cloudfunctions.net/prompt-eng-tracker?notebook=all-prompt-engineering-techniques--ethical-prompt-engineering)"
+   ]
   }
  ],
  "metadata": {

--- a/all_prompt_engineering_techniques/evaluating-prompt-effectiveness.ipynb
+++ b/all_prompt_engineering_techniques/evaluating-prompt-effectiveness.ipynb
@@ -601,6 +601,13 @@
     "expected_content = \"Overfitting occurs when a model learns the training data too well, including its noise and fluctuations, leading to poor generalization on new, unseen data.\"\n",
     "evaluate_prompt(prompt, expected_content)"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "![](https://europe-west1-prompt-eng-views-tracker.cloudfunctions.net/prompt-eng-tracker?notebook=all-prompt-engineering-techniques--evaluating-prompt-effectiveness)"
+   ]
   }
  ],
  "metadata": {

--- a/all_prompt_engineering_techniques/few-shot-learning.ipynb
+++ b/all_prompt_engineering_techniques/few-shot-learning.ipynb
@@ -370,6 +370,13 @@
     "accuracy = evaluate_model(few_shot_sentiment_classification, test_cases)\n",
     "print(f\"Model Accuracy: {accuracy:.2f}\")"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "![](https://europe-west1-prompt-eng-views-tracker.cloudfunctions.net/prompt-eng-tracker?notebook=all-prompt-engineering-techniques--few-shot-learning)"
+   ]
   }
  ],
  "metadata": {

--- a/all_prompt_engineering_techniques/instruction-engineering-notebook.ipynb
+++ b/all_prompt_engineering_techniques/instruction-engineering-notebook.ipynb
@@ -448,6 +448,13 @@
     "print(\"Final Instruction Output:\")\n",
     "print(get_completion(final_instruction))"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "![](https://europe-west1-prompt-eng-views-tracker.cloudfunctions.net/prompt-eng-tracker?notebook=all-prompt-engineering-techniques--instruction-engineering-notebook)"
+   ]
   }
  ],
  "metadata": {

--- a/all_prompt_engineering_techniques/intro-prompt-engineering-lesson.ipynb
+++ b/all_prompt_engineering_techniques/intro-prompt-engineering-lesson.ipynb
@@ -389,6 +389,13 @@
     "chain = problem_solving_prompt | llm\n",
     "print(chain.invoke(\"Calculate the compound interest on $1000 invested for 5 years at an annual rate of 5%, compounded annually.\").content)"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "![](https://europe-west1-prompt-eng-views-tracker.cloudfunctions.net/prompt-eng-tracker?notebook=all-prompt-engineering-techniques--intro-prompt-engineering-lesson)"
+   ]
   }
  ],
  "metadata": {

--- a/all_prompt_engineering_techniques/multilingual-prompting.ipynb
+++ b/all_prompt_engineering_techniques/multilingual-prompting.ipynb
@@ -411,6 +411,13 @@
     "    print_response(response)\n",
     "    print()"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "![](https://europe-west1-prompt-eng-views-tracker.cloudfunctions.net/prompt-eng-tracker?notebook=all-prompt-engineering-techniques--multilingual-prompting)"
+   ]
   }
  ],
  "metadata": {

--- a/all_prompt_engineering_techniques/negative-prompting.ipynb
+++ b/all_prompt_engineering_techniques/negative-prompting.ipynb
@@ -242,6 +242,13 @@
     "    refined_evaluation = evaluate_output(refined_response, constraints)\n",
     "    print(\"\\nRefined evaluation results:\", refined_evaluation)"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "![](https://europe-west1-prompt-eng-views-tracker.cloudfunctions.net/prompt-eng-tracker?notebook=all-prompt-engineering-techniques--negative-prompting)"
+   ]
   }
  ],
  "metadata": {

--- a/all_prompt_engineering_techniques/prompt-chaining-sequencing.ipynb
+++ b/all_prompt_engineering_techniques/prompt-chaining-sequencing.ipynb
@@ -419,6 +419,13 @@
     "result = robust_number_generation(topic)\n",
     "print(f\"Final result for topic '{topic}': {result}\")"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "![](https://europe-west1-prompt-eng-views-tracker.cloudfunctions.net/prompt-eng-tracker?notebook=all-prompt-engineering-techniques--prompt-chaining-sequencing)"
+   ]
   }
  ],
  "metadata": {

--- a/all_prompt_engineering_techniques/prompt-formatting-structure.ipynb
+++ b/all_prompt_engineering_techniques/prompt-formatting-structure.ipynb
@@ -499,6 +499,13 @@
     "    print(f\"Prompt {i}:\")\n",
     "    get_response(prompt)"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "![](https://europe-west1-prompt-eng-views-tracker.cloudfunctions.net/prompt-eng-tracker?notebook=all-prompt-engineering-techniques--prompt-formatting-structure)"
+   ]
   }
  ],
  "metadata": {

--- a/all_prompt_engineering_techniques/prompt-length-complexity-management.ipynb
+++ b/all_prompt_engineering_techniques/prompt-length-complexity-management.ipynb
@@ -449,6 +449,13 @@
     "tips = llm.invoke(tips_prompt).content\n",
     "print(tips)"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "![](https://europe-west1-prompt-eng-views-tracker.cloudfunctions.net/prompt-eng-tracker?notebook=all-prompt-engineering-techniques--prompt-length-complexity-management)"
+   ]
   }
  ],
  "metadata": {

--- a/all_prompt_engineering_techniques/prompt-optimization-techniques.ipynb
+++ b/all_prompt_engineering_techniques/prompt-optimization-techniques.ipynb
@@ -320,6 +320,13 @@
     "print(f\"Refined prompt score: {refined_score:.2f}\")\n",
     "print(f\"Improvement: {(refined_score - original_score):.2f} points\")"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "![](https://europe-west1-prompt-eng-views-tracker.cloudfunctions.net/prompt-eng-tracker?notebook=all-prompt-engineering-techniques--prompt-optimization-techniques)"
+   ]
   }
  ],
  "metadata": {

--- a/all_prompt_engineering_techniques/prompt-security-and-safety.ipynb
+++ b/all_prompt_engineering_techniques/prompt-security-and-safety.ipynb
@@ -413,6 +413,13 @@
     "\n",
     "run_security_tests()"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "![](https://europe-west1-prompt-eng-views-tracker.cloudfunctions.net/prompt-eng-tracker?notebook=all-prompt-engineering-techniques--prompt-security-and-safety)"
+   ]
   }
  ],
  "metadata": {

--- a/all_prompt_engineering_techniques/prompt-templates-variables-jinja2.ipynb
+++ b/all_prompt_engineering_techniques/prompt-templates-variables-jinja2.ipynb
@@ -440,6 +440,13 @@
     ")\n",
     "print(get_completion(prompt))"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "![](https://europe-west1-prompt-eng-views-tracker.cloudfunctions.net/prompt-eng-tracker?notebook=all-prompt-engineering-techniques--prompt-templates-variables-jinja2)"
+   ]
   }
  ],
  "metadata": {

--- a/all_prompt_engineering_techniques/role-prompting.ipynb
+++ b/all_prompt_engineering_techniques/role-prompting.ipynb
@@ -326,6 +326,13 @@
     "    print(response.content)\n",
     "    print(\"-\" * 50)"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "![](https://europe-west1-prompt-eng-views-tracker.cloudfunctions.net/prompt-eng-tracker?notebook=all-prompt-engineering-techniques--role-prompting)"
+   ]
   }
  ],
  "metadata": {

--- a/all_prompt_engineering_techniques/self-consistency.ipynb
+++ b/all_prompt_engineering_techniques/self-consistency.ipynb
@@ -685,6 +685,13 @@
     "    print(\"\\nConsistency Evaluation:\\n\", evaluation)\n",
     "    print(\"\\n\" + \"-\"*50 + \"\\n\")"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "![](https://europe-west1-prompt-eng-views-tracker.cloudfunctions.net/prompt-eng-tracker?notebook=all-prompt-engineering-techniques--self-consistency)"
+   ]
   }
  ],
  "metadata": {

--- a/all_prompt_engineering_techniques/specific-task-prompts.ipynb
+++ b/all_prompt_engineering_techniques/specific-task-prompts.ipynb
@@ -279,6 +279,13 @@
     "print(\"Generated Story:\")\n",
     "print(story)"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "![](https://europe-west1-prompt-eng-views-tracker.cloudfunctions.net/prompt-eng-tracker?notebook=all-prompt-engineering-techniques--specific-task-prompts)"
+   ]
   }
  ],
  "metadata": {

--- a/all_prompt_engineering_techniques/task-decomposition-prompts.ipynb
+++ b/all_prompt_engineering_techniques/task-decomposition-prompts.ipynb
@@ -397,6 +397,13 @@
     "overall_analysis = integrate_results(profitability_analysis, liquidity_analysis, cash_flow_analysis)\n",
     "print(\"Overall Financial Health Analysis:\\n\", overall_analysis)"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "![](https://europe-west1-prompt-eng-views-tracker.cloudfunctions.net/prompt-eng-tracker?notebook=all-prompt-engineering-techniques--task-decomposition-prompts)"
+   ]
   }
  ],
  "metadata": {

--- a/all_prompt_engineering_techniques/zero-shot-prompting.ipynb
+++ b/all_prompt_engineering_techniques/zero-shot-prompting.ipynb
@@ -337,6 +337,13 @@
     "\n",
     "compare_prompts(task, prompt_templates)"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "![](https://europe-west1-prompt-eng-views-tracker.cloudfunctions.net/prompt-eng-tracker?notebook=all-prompt-engineering-techniques--zero-shot-prompting)"
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
## What

Adds the 1x1 analytics **view pixel** to the README and to all **22 notebooks**, pointing at this repo's own views tracker (`prompt-eng-tracker`).

## Why

This repo currently records **0 views**. It had only *click* links (routed through the RAG_Techniques tracker) and **no view pixel**, so README and notebook page views were never counted, unlike RAG_Techniques, which carries the same pixel.

## Details

- README: one pixel appended (`?notebook=main-readme`).
- Each notebook: a final markdown cell with a unique `?notebook=<slug>` using the existing `--` hierarchy convention.
- Byte-preserving insertion; only the new cell is added. All 22 notebooks re-validated as valid JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added tracking elements to the README and all prompt engineering tutorial notebooks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->