### PR TITLE
Fix broken link in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,7 +56,7 @@ When adding a new prompt engineering technique to the repository, please follow 
 
 For example:
 ```
-1. [Intro-prompt-engineering-lesson 📝](hhttps://github.com/NirDiamant/Prompt_Engineering/blob/main/all_prompt_engineering_techniques/basic_prompt_construction.ipynb)
+1. [Intro-prompt-engineering-lesson 📝](https://github.com/NirDiamant/Prompt_Engineering/blob/main/all_prompt_engineering_techniques/basic_prompt_construction.ipynb)
 2. [Your New Technique 🆕](https://github.com/NirDiamant/Prompt_Engineering/blob/main/all_prompt_engineering_techniques/your_new_technique.ipynb)
 3. [Next Technique 🔜](https://github.com/NirDiamant/Prompt_Engineering/blob/main/all_prompt_engineering_techniques/next_technique.ipynb)
 ```


### PR DESCRIPTION
This fixes a typo in the example link in CONTRIBUTING.md. The URL starts with hhttps://, which makes the Markdown link invalid; it now uses the correct https:// scheme.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected a typo in the example README link for adding a new prompt engineering technique.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->