### PR TITLE
Tracked video section replacing the untracked text CTA

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,36 @@ One `npm install` adds the module's AI assistant to your Claude Code, and it gui
 
 [![DiamantAI's newsletter](images/substack_image.png)](https://newsletter.diamant-ai.com/?r=336pe4&utm_campaign=pub-share-checklist)
 
+<h2 align="center">🎬 Prefer video?</h2>
+
+<div align="center">
+
+*I break these ideas down into short, one-idea-per-episode explainers on YouTube.*
+
+<table>
+<tr>
+<td width="33%" align="center" valign="top">
+  <a href="https://europe-west1-rag-techniques-views-tracker.cloudfunctions.net/rag-techniques-tracker?notebook=prompt-engineering--readme&click=youtube-readme-llm&target=https%3A%2F%2Fwww.youtube.com%2Fwatch%3Fv%3DtKXvKKVQ1Dc&retarget=0&text=youtube-readme-llm"><img src="https://img.youtube.com/vi/tKXvKKVQ1Dc/mqdefault.jpg" width="100%" alt="How LLMs Actually Work (and Why AI Makes Things Up)"></a><br>
+  <b><a href="https://europe-west1-rag-techniques-views-tracker.cloudfunctions.net/rag-techniques-tracker?notebook=prompt-engineering--readme&click=youtube-readme-llm&target=https%3A%2F%2Fwww.youtube.com%2Fwatch%3Fv%3DtKXvKKVQ1Dc&retarget=0&text=youtube-readme-llm">How LLMs Actually Work (and Why AI Makes Things Up)</a></b><br>
+  <sub>recalling a fact and inventing one are literally the same move</sub>
+</td>
+<td width="33%" align="center" valign="top">
+  <a href="https://europe-west1-rag-techniques-views-tracker.cloudfunctions.net/rag-techniques-tracker?notebook=prompt-engineering--readme&click=youtube-readme-ctx&target=https%3A%2F%2Fwww.youtube.com%2Fwatch%3Fv%3Da7bteK6c3Ng&retarget=0&text=youtube-readme-ctx"><img src="https://img.youtube.com/vi/a7bteK6c3Ng/mqdefault.jpg" width="100%" alt="Context Is the New Code"></a><br>
+  <b><a href="https://europe-west1-rag-techniques-views-tracker.cloudfunctions.net/rag-techniques-tracker?notebook=prompt-engineering--readme&click=youtube-readme-ctx&target=https%3A%2F%2Fwww.youtube.com%2Fwatch%3Fv%3Da7bteK6c3Ng&retarget=0&text=youtube-readme-ctx">Context Is the New Code</a></b><br>
+  <sub>the shift from writing the code to shaping what the model sees</sub>
+</td>
+<td width="33%" align="center" valign="top">
+  <a href="https://europe-west1-rag-techniques-views-tracker.cloudfunctions.net/rag-techniques-tracker?notebook=prompt-engineering--readme&click=youtube-readme-cc&target=https%3A%2F%2Fwww.youtube.com%2Fwatch%3Fv%3D0fU8GdipOjc&retarget=0&text=youtube-readme-cc"><img src="https://img.youtube.com/vi/0fU8GdipOjc/mqdefault.jpg" width="100%" alt="Stop Thinking Claude Code Is Magic. Here's How It Works"></a><br>
+  <b><a href="https://europe-west1-rag-techniques-views-tracker.cloudfunctions.net/rag-techniques-tracker?notebook=prompt-engineering--readme&click=youtube-readme-cc&target=https%3A%2F%2Fwww.youtube.com%2Fwatch%3Fv%3D0fU8GdipOjc&retarget=0&text=youtube-readme-cc">Stop Thinking Claude Code Is Magic. Here's How It Works</a></b><br>
+  <sub>what the agent loop is actually doing on every turn</sub>
+</td>
+</tr>
+</table>
+
+[![Subscribe on YouTube](https://img.shields.io/youtube/channel/subscribers/UCatj5F2gohksvfNmnEpRnNA?style=social)](https://europe-west1-rag-techniques-views-tracker.cloudfunctions.net/rag-techniques-tracker?notebook=prompt-engineering--readme&click=youtube-subscribe-channel&target=https%3A%2F%2Fwww.youtube.com%2F%40DiamantAI%3Fsub_confirmation%3D1&retarget=0&text=youtube-subscribe-channel) &nbsp; [**Browse every episode →**](https://europe-west1-rag-techniques-views-tracker.cloudfunctions.net/rag-techniques-tracker?notebook=prompt-engineering--readme&click=youtube-all-episodes&target=https%3A%2F%2Fwww.youtube.com%2F%40DiamantAI&retarget=0&text=youtube-all-episodes)
+
+</div>
+
 ## Introduction
 
 Prompt engineering is at the forefront of artificial intelligence, revolutionizing the way we interact with and leverage AI technologies. This repository is designed to guide you through the development journey, from basic prompt structures to advanced, cutting-edge techniques.

--- a/README.md
+++ b/README.md
@@ -72,18 +72,24 @@ One `npm install` adds the module's AI assistant to your Claude Code, and it gui
 <table>
 <tr>
 <td width="33%" align="center" valign="top">
-  <a href="https://europe-west1-rag-techniques-views-tracker.cloudfunctions.net/rag-techniques-tracker?notebook=prompt-engineering--readme&click=youtube-readme-llm&target=https%3A%2F%2Fwww.youtube.com%2Fwatch%3Fv%3DtKXvKKVQ1Dc&retarget=0&text=youtube-readme-llm"><img src="https://img.youtube.com/vi/tKXvKKVQ1Dc/mqdefault.jpg" width="100%" alt="How LLMs Actually Work (and Why AI Makes Things Up)"></a><br>
-  <b><a href="https://europe-west1-rag-techniques-views-tracker.cloudfunctions.net/rag-techniques-tracker?notebook=prompt-engineering--readme&click=youtube-readme-llm&target=https%3A%2F%2Fwww.youtube.com%2Fwatch%3Fv%3DtKXvKKVQ1Dc&retarget=0&text=youtube-readme-llm">How LLMs Actually Work (and Why AI Makes Things Up)</a></b><br>
+  <a href="https://europe-west1-rag-techniques-views-tracker.cloudfunctions.net/rag-techniques-tracker?notebook=prompt-engineering--readme&amp;click=youtube-readme-llm&amp;target=https%3A%2F%2Fwww.youtube.com%2Fwatch%3Fv%3DtKXvKKVQ1Dc&amp;retarget=0&amp;text=youtube-readme-llm">
+    <img src="https://img.youtube.com/vi/tKXvKKVQ1Dc/mqdefault.jpg" width="100%" alt="">
+    <br><b>How LLMs Actually Work (and Why AI Makes Things Up)</b>
+  </a><br>
   <sub>recalling a fact and inventing one are literally the same move</sub>
 </td>
 <td width="33%" align="center" valign="top">
-  <a href="https://europe-west1-rag-techniques-views-tracker.cloudfunctions.net/rag-techniques-tracker?notebook=prompt-engineering--readme&click=youtube-readme-ctx&target=https%3A%2F%2Fwww.youtube.com%2Fwatch%3Fv%3Da7bteK6c3Ng&retarget=0&text=youtube-readme-ctx"><img src="https://img.youtube.com/vi/a7bteK6c3Ng/mqdefault.jpg" width="100%" alt="Context Is the New Code"></a><br>
-  <b><a href="https://europe-west1-rag-techniques-views-tracker.cloudfunctions.net/rag-techniques-tracker?notebook=prompt-engineering--readme&click=youtube-readme-ctx&target=https%3A%2F%2Fwww.youtube.com%2Fwatch%3Fv%3Da7bteK6c3Ng&retarget=0&text=youtube-readme-ctx">Context Is the New Code</a></b><br>
+  <a href="https://europe-west1-rag-techniques-views-tracker.cloudfunctions.net/rag-techniques-tracker?notebook=prompt-engineering--readme&amp;click=youtube-readme-ctx&amp;target=https%3A%2F%2Fwww.youtube.com%2Fwatch%3Fv%3Da7bteK6c3Ng&amp;retarget=0&amp;text=youtube-readme-ctx">
+    <img src="https://img.youtube.com/vi/a7bteK6c3Ng/mqdefault.jpg" width="100%" alt="">
+    <br><b>Context Is the New Code</b>
+  </a><br>
   <sub>the shift from writing the code to shaping what the model sees</sub>
 </td>
 <td width="33%" align="center" valign="top">
-  <a href="https://europe-west1-rag-techniques-views-tracker.cloudfunctions.net/rag-techniques-tracker?notebook=prompt-engineering--readme&click=youtube-readme-cc&target=https%3A%2F%2Fwww.youtube.com%2Fwatch%3Fv%3D0fU8GdipOjc&retarget=0&text=youtube-readme-cc"><img src="https://img.youtube.com/vi/0fU8GdipOjc/mqdefault.jpg" width="100%" alt="Stop Thinking Claude Code Is Magic. Here's How It Works"></a><br>
-  <b><a href="https://europe-west1-rag-techniques-views-tracker.cloudfunctions.net/rag-techniques-tracker?notebook=prompt-engineering--readme&click=youtube-readme-cc&target=https%3A%2F%2Fwww.youtube.com%2Fwatch%3Fv%3D0fU8GdipOjc&retarget=0&text=youtube-readme-cc">Stop Thinking Claude Code Is Magic. Here's How It Works</a></b><br>
+  <a href="https://europe-west1-rag-techniques-views-tracker.cloudfunctions.net/rag-techniques-tracker?notebook=prompt-engineering--readme&amp;click=youtube-readme-cc&amp;target=https%3A%2F%2Fwww.youtube.com%2Fwatch%3Fv%3D0fU8GdipOjc&amp;retarget=0&amp;text=youtube-readme-cc">
+    <img src="https://img.youtube.com/vi/0fU8GdipOjc/mqdefault.jpg" width="100%" alt="">
+    <br><b>Stop Thinking Claude Code Is Magic. Here's How It Works</b>
+  </a><br>
   <sub>what the agent loop is actually doing on every turn</sub>
 </td>
 </tr>


### PR DESCRIPTION
## Why

7,708 stars and no working YouTube CTA. The uncommitted local version pointed at a **raw `youtube.com` URL** — routing around the click tracker, so it was unmeasurable even once shipped.

Measured on RAG_Techniques, normalising `clicks_by_link` to **clicks per day live**, the video block runs **38.0/day vs 37.7 for the entire nine-link book stack.** The video CTA isn't weak — it's absent from every surface but one repo.

## What changed

A dedicated **"Prefer video?"** section above `## Introduction`, with real YouTube thumbnails via `img.youtube.com` (no repo bloat) so the block carries a play affordance rather than being a line of italic text. The book gets an image, a title link and a CTA; video now gets the same treatment.

No tutorial-index README in this PR — unlike the other three repos, this one has no single high-traffic directory page equivalent to `all_rag_techniques/`.

## Measurement

Links route through **`rag-techniques-tracker`** with `notebook=prompt-engineering--readme` and distinct `click_id`s, matching how this repo's book and course CTAs already work. The **`prompt-eng` tracker 400s on a `youtube.com` target** — not allowlisted, so it can't carry these.

All URLs curl-tested → `302` to the correct watch page.

## Note on your local WIP

You had 4 uncommitted lines in `README.md` on `main` adding the untracked version of this CTA. Superseded here and saved in `git stash`; `.pr_agent.toml` left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a centered “Prefer video?” section with three linked YouTube episodes.
  * Included episode descriptions, thumbnails, a YouTube subscription badge, and a link to browse all episodes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->